### PR TITLE
Allow reflexive permission grants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 pkgver!=node -e 'console.log(JSON.parse(fs.readFileSync("package.json")).version)'
 
-version?=${pkgver}
+version?=v${pkgver}
 suffix?=
 registry?=ghcr.io/amrc-factoryplus
 repo?=acs-auth

--- a/editor/editor.js
+++ b/editor/editor.js
@@ -402,7 +402,8 @@ function EffPrinc (props) {
     const [eff, set_eff] = useState(null);
 
     useEffect(async () => {
-        const list = await fetch_json("auth", `/authz/effective/${princ}`);
+        const e_princ = encodeURIComponent(princ);
+        const list = await fetch_json("auth", `/authz/effective/${e_princ}`);
         sort_acl(list);
         set_eff(list);
     }, []);

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -4,6 +4,8 @@
  * Copyright 2022 AMRC
  */
 
+import { Special } from "./uuids.js";
+
 /* Queries is a separate class, because sometimes we want to query on
  * the database directly, and sometimes we need to query using a query
  * function for a transaction. The model inherits from this class. */
@@ -22,7 +24,11 @@ export default class Queries {
          * members, is incorrect. If I normalise to a table of UUIDs
          * then I can make it an ordinary left join. */
         const dbr = await this.query(`
-            select a.permission, a.target
+            select a.permission, 
+                case a.target
+                    when '${Special.Self}'::uuid then $1
+                    else a.target
+                end
             from resolved_ace a
             where a.principal = $1
                 and a.permission in (

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -26,9 +26,9 @@ export default class Queries {
         const dbr = await this.query(`
             select a.permission, 
                 case a.target
-                    when '${Special.Self}'::uuid then $1
+                    when '${Special.Self}'::uuid then a.principal
                     else a.target
-                end
+                end target
             from resolved_ace a
             where a.principal = $1
                 and a.permission in (
@@ -170,7 +170,11 @@ export default class Queries {
 
     async effective_get (principal) {
         const dbr = await this.query(`
-            select p.kerberos, a.principal, a.permission, a.target
+            select p.kerberos, a.principal, a.permission,
+                case a.target
+                    when '${Special.Self}'::uuid then a.principal
+                    else a.target
+                end target
             from resolved_ace a
                 join principal p on a.principal = p.uuid
             where p.kerberos = $1

--- a/lib/uuids.js
+++ b/lib/uuids.js
@@ -14,7 +14,7 @@ export const Perm = {
     Manage_Krb:     "327c4cc8-9c46-4e1e-bb6b-257ace37b0f6",
 };
 
-export Special = {
+export const Special = {
     Wildcard:       "00000000-0000-0000-0000-000000000000",
     Self:           "5855a1cc-46d8-4b16-84f8-ab3916ecb230",
 };

--- a/lib/uuids.js
+++ b/lib/uuids.js
@@ -4,7 +4,7 @@
  * Copyright 2022 AMRC
  */
 
-const Perm = {
+export const Perm = {
     All:            "50b727d4-3faa-40dc-b347-01c99a226c58",
     Read_ACL:       "ba566181-0e8a-405b-b16e-3fb89130fbee",
     Read_Krb:       "e8c9c0f7-0d54-4db2-b8d6-cd80c45f6a5c",
@@ -14,4 +14,7 @@ const Perm = {
     Manage_Krb:     "327c4cc8-9c46-4e1e-bb6b-257ace37b0f6",
 };
 
-export { Perm };
+export Special = {
+    Wildcard:       "00000000-0000-0000-0000-000000000000",
+    Self:           "5855a1cc-46d8-4b16-84f8-ab3916ecb230",
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acs-auth",
-  "version": "1.0.1",
+  "version": "1.3.0",
   "description": "The Authorisation component of the AMRC Connectivity Stack",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
Create a special UUID to be used as the Target of an ACE, which grants the requesting principal the relevant permission on itself.

This means the current 'Role: Edge Node', which is a group of permissions granted for each edge node to itself, can be replaced with a group of principals. Those permissions which needed the node UUID as target can be granted with the new reflexive UUID instead.

The permission group only worked because all permissions in the group either wanted the node as target or ignored their target. A user group is more flexible, as specific additional grants can be made with other targets; for example, Edge Agents need to be able to read their configs from the ConfigDB. It also means that the process for setting up an Edge Agent account is simplified: instead of creating a selection of specific ACL entries, the new user account is just placed in the Edge Agent group.