### PR TITLE
Fix cosign errors on build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,32 +6,8 @@ env:
 on:
   release:
     types: [ published ]
-    # Trigger only when a release with tag v*.*.* is published
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  update-version:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Update version in package.json
-        run: |
-          CURRENT_TAG=${GITHUB_REF#refs/tags/}
-          echo "Current tag: $CURRENT_TAG"
-          VERSION="${CURRENT_TAG#v}"
-          echo "Updating version to: $VERSION"
-          jq ".version = \"$VERSION\"" package.json > package.json.tmp
-          mv package.json.tmp package.json
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
-        with:
-          title: Update package.json version
-          branch: update-version
-          commit-message: Update package.json version
-          body: Update the version of `package.json` as part of release process
-          delete-branch: true
-          base: main
   build:
     runs-on: ubuntu-latest
     permissions:
@@ -47,9 +23,7 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
-        with:
-          cosign-release: 'v1.13.1'
+        uses: sigstore/cosign-installer@v3.1.1
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
@@ -98,4 +72,4 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push.outputs.digest }}


### PR DESCRIPTION
* Remove the update-version step, it's never used.
* Perform builds for all releases, I want this to run on dev releases.
* Update the cosign code.